### PR TITLE
Bump jira-python version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ __version__.py
 .output
 .virtualenv
 .vscode
+.idea
 .python-version
 *.egg
 *.egg-info/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "jira_report_generator"
-version = "1.15.1"
+version = "1.16.0"
 authors = [
   { name="Denis Maitak", email="denis.maitak@saritasa.com" },
 ]
@@ -17,7 +17,7 @@ classifiers = [
     "Operating System :: OS Independent",
 ]
 dependencies = [
-    "jira==3.8.0",
+    "jira==3.10.5",
     "pandas==2.2.3",
     "python-decouple==3.8",
     "jinja2==3.1.6",

--- a/requirements.in
+++ b/requirements.in
@@ -1,5 +1,5 @@
 ipython
-jira==3.8.0
+jira==3.10.5
 pandas==2.2.3
 python-decouple
 jinja2==3.1.*

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,7 +26,7 @@ jedi==0.18.2
     # via ipython
 jinja2==3.1.5
     # via -r requirements.in
-jira==3.8.0
+jira==3.10.5
     # via -r requirements.in
 markupsafe==2.1.2
     # via jinja2
@@ -48,8 +48,6 @@ pexpect==4.8.0
     # via ipython
 pickleshare==0.7.5
     # via ipython
-pillow==11.0.0
-    # via jira
 prompt-toolkit==3.0.38
     # via ipython
 ptyprocess==0.7.0


### PR DESCRIPTION
- JIRA removes some API endpoints, we must update to higher jira-python version to use new endpoints
- [Github issue](https://github.com/pycontribs/jira/issues/2369)